### PR TITLE
chore: update to stdlib slog and slices

### DIFF
--- a/calculator/mod_parser.go
+++ b/calculator/mod_parser.go
@@ -3,10 +3,10 @@ package calculator
 import (
 	"math"
 	"regexp"
+	"slices"
 	"strings"
 
 	utils2 "github.com/Vilsol/go-pob-data/utils"
-	"golang.org/x/exp/slices"
 
 	"github.com/Vilsol/go-pob-data/poe"
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/andybalholm/brotli v1.1.1
 	github.com/dominikbraun/graph v0.23.0
 	github.com/lmittmann/tint v1.0.5
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	gopkg.in/djherbis/fscache.v0 v0.10.1
 )
 
@@ -28,6 +27,7 @@ require (
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/tinylib/msgp v1.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/term v0.25.0 // indirect

--- a/utils/map.go
+++ b/utils/map.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func Has[K comparable, V any](m map[K]V, key K) bool {


### PR DESCRIPTION
Note: This change will require Go 1.23+.