### PR TITLE
feat: mastery node visual overlay

### DIFF
--- a/frontend/src/lib/components/SkillTree.svelte
+++ b/frontend/src/lib/components/SkillTree.svelte
@@ -73,7 +73,7 @@
 
   let selectOption = (node: Node, optionIndex: number) => {
     // Todo: allocate mastery option to currentBuild
-    console.info(`Selected mastery option ${optionIndex} for mastery node ${node.name} - nodeId ${node.skill}`);
+    console.debug(`Selected mastery option ${optionIndex} for mastery node ${node.name} - nodeId ${node.skill}`);
     allocatePathToTarget(node.skill ?? -1);
   };
 

--- a/frontend/src/lib/components/SkillTree.svelte
+++ b/frontend/src/lib/components/SkillTree.svelte
@@ -37,7 +37,8 @@
   const openNodeOptions = (node: Node) => {
     openOverlay({
       component: NodeSelectionOptions,
-      props: { node: node, onSelectOption: selectOption }
+      props: { node: node, onSelectOption: selectOption },
+      backdropClose: true
     });
   };
 

--- a/frontend/src/lib/components/SkillTree.svelte
+++ b/frontend/src/lib/components/SkillTree.svelte
@@ -23,6 +23,8 @@
   import { syncWrap } from '../go/worker';
   import { get, writable } from 'svelte/store';
   import { logError } from '$lib/utils';
+  import { openOverlay } from '$lib/overlay';
+  import NodeSelectionOptions from './overlays/NodeSelectionOptions.svelte';
 
   interface Props {
     skillTree: Tree;
@@ -31,6 +33,14 @@
   }
 
   let { skillTree, skillTreeVersion, children }: Props = $props();
+
+  const openNodeOptions = (node: Node) => {
+    openOverlay({
+      // Todo: fixup type compatibility with base overlay
+      component: NodeSelectionOptions,
+      props: { node: node, onSelectOption: selectOption }
+    });
+  };
 
   let currentClass: string | undefined = $state();
   $effect(() => {
@@ -47,6 +57,24 @@
     $currentBuild?.Build?.PassiveNodes?.then((newNodes) => (activeNodes = newNodes)).catch(logError);
   });
 
+  let allocatePathToTarget = (nodeId: number) => {
+    const rootNodes = classStartNodes[skillTree.classes.findIndex((c) => c.name === currentClass)];
+    void syncWrap?.CalculateTreePath(skillTreeVersion || '3_18', [...rootNodes, ...(activeNodes ?? [])], nodeId).then((pathData) => {
+      if (!pathData) {
+        return;
+      }
+
+      // The first in the path is always an already allocated node
+      const isRootInPath = rootNodes.includes(pathData[0]);
+      void syncWrap?.AllocateNodes(isRootInPath ? pathData : pathData.slice(1));
+      currentBuild.set($currentBuild);
+    });
+  };
+
+  let selectOption = (node: Node, optionIndex: number) => {
+    allocatePathToTarget(node.skill ?? -1);
+  };
+
   let clickNode = (node: Node) => {
     const nodeId = node.skill ?? -1;
     if (activeNodes?.includes(nodeId)) {
@@ -54,17 +82,11 @@
       currentBuild.set($currentBuild);
     } else {
       // TODO: Needs support for ascendancies or any other disconnect groups
-      const rootNodes = classStartNodes[skillTree.classes.findIndex((c) => c.name === currentClass)];
-      void syncWrap?.CalculateTreePath(skillTreeVersion || '3_18', [...rootNodes, ...(activeNodes ?? [])], nodeId).then((pathData) => {
-        if (!pathData) {
-          return;
-        }
-
-        // The first in the path is always an already allocated node
-        const isRootInPath = rootNodes.includes(pathData[0]);
-        void syncWrap?.AllocateNodes(isRootInPath ? pathData : pathData.slice(1));
-        currentBuild.set($currentBuild);
-      });
+      if (node.isMastery) {
+        openNodeOptions(node);
+        return;
+      }
+      allocatePathToTarget(nodeId);
     }
   };
 
@@ -507,6 +529,31 @@
         });
 
         offset += 20;
+      } else if (hNode.isMastery) {
+        allLines.push({
+          text: 'Available mastery options are:',
+          offset,
+          special: false
+        });
+        offset += 20;
+        hNode.masteryEffects?.forEach((effect) => {
+          if (allLines.length > 0) {
+            offset += 10;
+          }
+          effect.stats.forEach((stat) => {
+            stat.split('\n').forEach((line) => {
+              if (allLines.length > 0) {
+                offset += 10;
+              }
+              allLines.push({
+                text: stat ?? 'N/A',
+                offset,
+                special: true
+              });
+              offset += 20;
+            });
+          });
+        });
       }
 
       const titleHeight = 55;

--- a/frontend/src/lib/components/SkillTree.svelte
+++ b/frontend/src/lib/components/SkillTree.svelte
@@ -34,14 +34,6 @@
 
   let { skillTree, skillTreeVersion, children }: Props = $props();
 
-  const openNodeOptions = (node: Node) => {
-    openOverlay({
-      component: NodeSelectionOptions,
-      props: { node: node, onSelectOption: selectOption },
-      backdropClose: true
-    });
-  };
-
   let currentClass: string | undefined = $state();
   $effect(() => {
     $currentBuild?.Build.ClassName.then((newClass) => (currentClass = newClass)).catch(logError);
@@ -75,6 +67,14 @@
     // Todo: allocate mastery option to currentBuild
     console.debug(`Selected mastery option ${optionIndex} for mastery node ${node.name} - nodeId ${node.skill}`);
     allocatePathToTarget(node.skill ?? -1);
+  };
+
+  const openNodeOptions = (node: Node) => {
+    openOverlay({
+      component: NodeSelectionOptions,
+      props: { node: node, onSelectOption: selectOption },
+      backdropClose: true
+    });
   };
 
   let clickNode = (node: Node) => {
@@ -543,7 +543,7 @@
             offset += 10;
           }
           effect.stats.forEach((stat) => {
-            stat.split('\n').forEach((line) => {
+            stat.split('\n').forEach(() => {
               if (allLines.length > 0) {
                 offset += 10;
               }

--- a/frontend/src/lib/components/SkillTree.svelte
+++ b/frontend/src/lib/components/SkillTree.svelte
@@ -72,6 +72,8 @@
   };
 
   let selectOption = (node: Node, optionIndex: number) => {
+    // Todo: allocate mastery option to currentBuild
+    console.info(`Selected mastery option ${optionIndex} for mastery node ${node.name} - nodeId ${node.skill}`);
     allocatePathToTarget(node.skill ?? -1);
   };
 

--- a/frontend/src/lib/components/SkillTree.svelte
+++ b/frontend/src/lib/components/SkillTree.svelte
@@ -36,7 +36,6 @@
 
   const openNodeOptions = (node: Node) => {
     openOverlay({
-      // Todo: fixup type compatibility with base overlay
       component: NodeSelectionOptions,
       props: { node: node, onSelectOption: selectOption }
     });

--- a/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
+++ b/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { fontScaling } from '$lib/global';
+  import type { Node } from '../../skill_tree/types';
+  let {
+    node,
+    onSelectOption,
+    onclose
+  }: {
+    node: Node;
+    onSelectOption: (node: Node, optionIdex: number) => void;
+    onclose: () => void;
+  } = $props();
+
+  type lineItem = {
+    text: string;
+  };
+
+  const getLineOptions = (node: Node): lineItem[] => {
+    const allLines: lineItem[] = [];
+
+    node.masteryEffects?.forEach((effect) => {
+      effect.stats.forEach((stat) => {
+        stat.split('\n').forEach(() => {
+          allLines.push({
+            text: stat ?? 'N/A'
+          });
+        });
+      });
+    });
+    return allLines;
+  };
+
+  const getOptionOnClick = (index: number) => {
+    return clickSelectionOption(index);
+  };
+
+  let clickSelectionOption = (index: number) => (event: Event) => {
+    if (!node) {
+      console.warn('Attempted to select an option without underlying node available.');
+      return;
+    }
+    onSelectOption(node, index);
+    onclose();
+  };
+
+  let lineOptions = getLineOptions(node);
+</script>
+
+<div class="flex flex-col gap-4">
+  <fieldset class="border border-white bg-neutral-900 p-2 mt-4 min-w-[15vw]">
+    <legend class="container"></legend>
+    <div class="side-by-side-max-content w-full">
+      <div class="flex flex-row gap-1">
+        <ol class="options-list">
+          {#each lineOptions as option, i}
+            <li class="option_${i}" id="test" onclick={getOptionOnClick(i)}>{option.text}</li>
+          {/each}
+        </ol>
+      </div>
+    </div>
+  </fieldset>
+
+  <div class="flex flex-row items-center justify-center">
+    <button class="container" onclick={onclose}>Close</button>
+  </div>
+</div>
+
+<style>
+  .options-list li:hover {
+    width: 100%;
+    border-radius: 0.2em;
+    background-color: var(--color, hsla(225, 29%, 65%, 0.672));
+  }
+
+  .options-list {
+    text-align: left;
+  }
+</style>

--- a/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
+++ b/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { fontScaling } from '$lib/global';
   import type { Node } from '../../skill_tree/types';
 
   interface NodeSelectionOptionsProps {
@@ -19,10 +18,10 @@
     text: string;
   };
 
-  const getLineOptions = (node: Node): lineItem[] => {
+  const getLineOptions = (nodeToDescribe: Node): lineItem[] => {
     const allLines: lineItem[] = [];
 
-    node.masteryEffects?.forEach((effect) => {
+    nodeToDescribe.masteryEffects?.forEach((effect) => {
       allLines.push({
         text: effect.stats.join('\n') ?? 'N/A'
       });
@@ -30,11 +29,7 @@
     return allLines;
   };
 
-  const getOptionOnSelect = (index: number) => {
-    return selectionOption(index);
-  };
-
-  let selectionOption = (index: number) => (_: Event) => {
+  let selectionOption = (index: number) => () => {
     if (!node) {
       console.warn('Attempted to select an option without underlying node available.');
       onclose();
@@ -43,6 +38,7 @@
     onclose();
   };
 
+  const getOptionOnSelect = (index: number) => selectionOption(index);
   let lineOptions = getLineOptions(node);
 </script>
 

--- a/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
+++ b/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
@@ -34,11 +34,11 @@
     return allLines;
   };
 
-  const getOptionOnClick = (index: number) => {
-    return clickSelectionOption(index);
+  const getOptionOnSelect = (index: number) => {
+    return selectionOption(index);
   };
 
-  let clickSelectionOption = (index: number) => (_: Event) => {
+  let selectionOption = (index: number) => (_: Event) => {
     if (!node) {
       console.warn('Attempted to select an option without underlying node available.');
       onclose();
@@ -57,7 +57,7 @@
       <div class="flex flex-row gap-1">
         <ol class="options-list">
           {#each lineOptions as option, i}
-            <li class="option_${i}" id="test" onclick={getOptionOnClick(i)}>{option.text}</li>
+            <li role="menuitem" class="option_${i}" onclick={getOptionOnSelect(i)} onkeydown={getOptionOnSelect(i)}>{option.text}</li>
           {/each}
         </ol>
       </div>

--- a/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
+++ b/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
@@ -38,10 +38,10 @@
     return clickSelectionOption(index);
   };
 
-  let clickSelectionOption = (index: number) => (event: Event) => {
+  let clickSelectionOption = (index: number) => (_: Event) => {
     if (!node) {
       console.warn('Attempted to select an option without underlying node available.');
-      return;
+      onclose();
     }
     onSelectOption(node, index);
     onclose();

--- a/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
+++ b/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
   import { fontScaling } from '$lib/global';
   import type { Node } from '../../skill_tree/types';
+
+  interface NodeSelectionOptionsProps {
+    node: Node;
+    onSelectOption: (node: Node, optionIdex: number) => void;
+  }
+
   let {
     node,
     onSelectOption,
     onclose
   }: {
-    node: Node;
-    onSelectOption: (node: Node, optionIdex: number) => void;
     onclose: () => void;
-  } = $props();
+  } & NodeSelectionOptionsProps = $props();
 
   type lineItem = {
     text: string;

--- a/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
+++ b/frontend/src/lib/components/overlays/NodeSelectionOptions.svelte
@@ -23,12 +23,8 @@
     const allLines: lineItem[] = [];
 
     node.masteryEffects?.forEach((effect) => {
-      effect.stats.forEach((stat) => {
-        stat.split('\n').forEach(() => {
-          allLines.push({
-            text: stat ?? 'N/A'
-          });
-        });
+      allLines.push({
+        text: effect.stats.join('\n') ?? 'N/A'
       });
     });
     return allLines;
@@ -50,14 +46,14 @@
   let lineOptions = getLineOptions(node);
 </script>
 
-<div class="flex flex-col gap-4">
+<div class="flex flex-col gap-2">
   <fieldset class="border border-white bg-neutral-900 p-2 mt-4 min-w-[15vw]">
-    <legend class="container"></legend>
-    <div class="side-by-side-max-content w-full">
+    <legend class="container">{node.name}</legend>
+    <div class="container">
       <div class="flex flex-row gap-1">
         <ol class="options-list">
           {#each lineOptions as option, i}
-            <li role="menuitem" class="option_${i}" onclick={getOptionOnSelect(i)} onkeydown={getOptionOnSelect(i)}>{option.text}</li>
+            <li role="menuitem" id="option_${i}" onclick={getOptionOnSelect(i)} onkeydown={getOptionOnSelect(i)}>{option.text}</li>
           {/each}
         </ol>
       </div>
@@ -78,5 +74,10 @@
 
   .options-list {
     text-align: left;
+    white-space: pre-wrap;
+  }
+
+  .options-list li {
+    margin: 5px;
   }
 </style>

--- a/frontend/src/lib/overlay.ts
+++ b/frontend/src/lib/overlay.ts
@@ -1,12 +1,12 @@
 import { get, writable } from 'svelte/store';
 import type { Component } from 'svelte';
 
-export interface OverlayConfig<TCompProps = {}> {
+export interface OverlayConfig<TCompProps = object> {
   component: Component<{ onclose: () => void } & TCompProps>;
   props?: TCompProps;
   backdropClose?: boolean;
 }
 
-export const overlays = writable<OverlayConfig<any>[]>([]);
+export const overlays = writable<OverlayConfig<object>[]>([]);
 
-export const openOverlay = <T = {}>(newOverlay: OverlayConfig<T>) => overlays.set([...get(overlays), newOverlay]);
+export const openOverlay = <T = object>(newOverlay: OverlayConfig<T>) => overlays.set([...get(overlays), newOverlay]);

--- a/frontend/src/lib/overlay.ts
+++ b/frontend/src/lib/overlay.ts
@@ -1,12 +1,12 @@
 import { get, writable } from 'svelte/store';
 import type { Component } from 'svelte';
 
-export interface OverlayConfig {
-  component: Component<{ onclose: () => void }>;
-  props?: Record<string, unknown>;
+export interface OverlayConfig<TCompProps = {}> {
+  component: Component<{ onclose: () => void } & TCompProps>;
+  props?: TCompProps;
   backdropClose?: boolean;
 }
 
-export const overlays = writable<OverlayConfig[]>([]);
+export const overlays = writable<OverlayConfig<any>[]>([]);
 
-export const openOverlay = (newOverlay: OverlayConfig) => overlays.set([...get(overlays), newOverlay]);
+export const openOverlay = <T = {}>(newOverlay: OverlayConfig<T>) => overlays.set([...get(overlays), newOverlay]);


### PR DESCRIPTION
Hey! First PR to this project so apologies if this doesn't match any conventions, I had a look across the previous PRs for a standard and went with this 👍 

# What

Incremental change on top of the actually hard work pathing to nodes already done by [Rybadour](https://github.com/Rybadour) in a previous PR.
This change adds a simple overlay for selecting the mastery option if selecting a Mastery Node on the tree. This behaviour is implemented to match the way this popup behaves in PoB, but will close on background click unlike PoB as this behaviour might feel more intuitive. Given we will also need to select attribute nodes in PoE2 this behaviour is probably going to be required for many more pathing nodes than just Masteries.
This is visual/frontend only, no change to the backend build yet since I would probably just break things until I get more up to speed. Added a comment highlighting this in the option selection callback on the skill tree.

Hover effect enhancement:
![image](https://github.com/user-attachments/assets/646e4cfa-f61a-4344-ae46-45ba2113c0bb)

Option selection overlay:
![image](https://github.com/user-attachments/assets/a7ae8c26-9036-4a39-bf17-fcf822ecbda2)

Option selection with multiline option hovered for selection
![image](https://github.com/user-attachments/assets/10ec03ef-92ba-4209-a69a-f17cbe944757)

Note the close button is outside the fieldset aligned with the Options menu styling for now.

# Why

Having the visual selection mechanism implemented for masteries can help build towards being able to implement selection. I'm also getting up to speed with the code base so keen to make a small change and check in to see if I've missed some obvious styling or conventions - I wasn't able to access the docs/rundown.md link so probably made some rookie errors feel free to nitpick them!

# Testing

I didn't see any obvious testing for the frontend component behaviour. Is this something we'd be interested in having in future?If so I could spend some effort looking into it. Validated visually and by checking the currentBuild that there was no regression in behaviour with the allocation of nodes. The path to the chosen Mastery is not allocated if the option is escaped, in line with PoB behaviour.

