### PR TITLE
fix: black bg for select input dropdown options

### DIFF
--- a/frontend/src/app.postcss
+++ b/frontend/src/app.postcss
@@ -82,6 +82,10 @@ select.input {
   }
 }
 
+select.input option {
+  @apply bg-black;
+}
+
 .select-wrapper {
   @apply relative p-0;
   position: relative;


### PR DESCRIPTION
Styles "select.input option" with bg-black, which should only affect dropdowns with the \<option\> tag used inside.
![{A9958E6B-C1AF-47CF-9F40-4A0F4D50915D}](https://github.com/user-attachments/assets/b5c4ba58-1dbf-487a-a454-58644d6a4c64)
![image](https://github.com/user-attachments/assets/ee25b2e6-b409-481e-bc24-b86fbcbeec0e)

I'm new to this codebase, so just poking around, I can see a handful of hardcoded color decisions in the css here, so figured it may be an acceptable option. Let me know if there's anything I've missed :)

## Not so desirable, other method
Initially simply removing the bg-transparent for all input components fixed the white background for dropdowns, however you can see the flow on effect from that was making inputs have a grey background, instead of black how it is now 
![image](https://github.com/user-attachments/assets/e4e19675-8f1b-4420-a6b9-7b8a258dc028)
Left is with no transparent background, which has a more grey input color.
It appears to me like the issue is something to do with background-color: transparent not properly using the black color of the content behind it, when it is coming from a dropdown, unlike the input boxes, which pick it up fine.