### PR TITLE
feat: update ClassID & AscendencyID as enums

### DIFF
--- a/calculator/env.go
+++ b/calculator/env.go
@@ -629,7 +629,7 @@ func InitEnv(build *pob.PathOfBuilding, envCache *EnvironmentCache, mode OutputM
 		env.Player.WeaponData1 = &SkillData{}
 	}
 
-	for k, v := range data.UnarmedWeaponData[data.ClassIDs[env.Spec.ClassName]] {
+	for k, v := range data.UnarmedWeaponData[env.Spec.ClassID] {
 		utils.Set(env.Player.WeaponData1, k, v)
 	}
 

--- a/calculator/passive_spec.go
+++ b/calculator/passive_spec.go
@@ -19,7 +19,9 @@ type PassiveSpec struct {
 	SubGraphs          map[string]interface{} // TODO Implement
 	MasterySelections  map[string]interface{} // TODO Implement
 
+	ClassID        data.ClassID
 	ClassName      data.ClassName
+	AscendancyID   data.AscendancyID
 	AscendancyName data.AscendancyName
 
 	AllocatedNotableCount int
@@ -42,10 +44,10 @@ func (p *PassiveSpec) Tree() *data.Tree {
 }
 
 func (p *PassiveSpec) Class() data.Class {
-	return p.Tree().Classes[data.ClassIDs[p.ClassName]]
+	return p.Tree().Classes[p.ClassID]
 }
 
-func (p *PassiveSpec) SelectClass(className data.ClassName) {
+func (p *PassiveSpec) SelectClass(classID data.ClassID) {
 	/*
 		TODO Implement
 		if self.curClassId then
@@ -56,7 +58,8 @@ func (p *PassiveSpec) SelectClass(className data.ClassName) {
 		end
 	*/
 
-	p.ClassName = className
+	p.ClassID = classID
+	p.ClassName = data.ClassNameByID[classID]
 
 	/*
 		TODO Implement
@@ -66,11 +69,12 @@ func (p *PassiveSpec) SelectClass(className data.ClassName) {
 		self.allocNodes[startNode.id] = startNode
 	*/
 
-	p.SelectAscendancyClass(data.ClassAscendancies[className][0])
+	p.SelectAscendancyClass(data.ClassAscendancies[p.ClassID][0])
 }
 
-func (p *PassiveSpec) SelectAscendancyClass(ascendancyName data.AscendancyName) {
-	p.AscendancyName = ascendancyName
+func (p *PassiveSpec) SelectAscendancyClass(ascendancyID data.AscendancyID) {
+	p.AscendancyID = ascendancyID
+	p.AscendancyName = data.AscendancyNameByID[ascendancyID]
 
 	/*
 		TODO Implement

--- a/data/constants.go
+++ b/data/constants.go
@@ -224,14 +224,14 @@ var MonsterAllyLifeTable = []float64{0, 15, 17, 20, 23, 26, 30, 33, 37, 41, 46, 
 var MonsterDamageTable = []float64{0, 4.9899997711182, 5.5599999427795, 6.1599998474121, 6.8099999427795, 7.5, 8.2299995422363, 9, 9.8199996948242, 10.699999809265, 11.619999885559, 12.60000038147, 13.640000343323, 14.739999771118, 15.909999847412, 17.139999389648, 18.450000762939, 19.829999923706, 21.290000915527, 22.840000152588, 24.469999313354, 26.190000534058, 28.010000228882, 29.940000534058, 31.959999084473, 34.110000610352, 36.360000610352, 38.75, 41.259998321533, 43.909999847412, 46.700000762939, 49.650001525879, 52.75, 56.009998321533, 59.450000762939, 63.080001831055, 66.889999389648, 70.910003662109, 75.129997253418, 79.580001831055, 84.26000213623, 89.180000305176, 94.349998474121, 99.800003051758, 105.51999664307, 111.5299987793, 117.86000061035, 124.5, 131.49000549316, 138.83000183105, 146.5299987793, 154.63000488281, 163.13999938965, 172.07000732422, 181.44999694824, 191.30000305176, 201.63000488281, 212.47999572754, 223.86999511719, 235.83000183105, 248.36999511719, 261.5299987793, 275.32998657227, 289.82000732422, 305.01000976563, 320.94000244141, 337.64999389648, 355.17999267578, 373.54998779297, 392.80999755859, 413.01000976563, 434.17999267578, 456.36999511719, 479.61999511719, 504, 529.53997802734, 556.29998779297, 584.34997558594, 613.72998046875, 644.5, 676.75, 710.52001953125, 745.89001464844, 782.94000244141, 821.72998046875, 862.35998535156, 904.90002441406, 949.44000244141, 996.07000732422, 1044.8900146484, 1096, 1149.5, 1205.5, 1264.1099853516, 1325.4499511719, 1389.6400146484, 1456.8199462891, 1527.1199951172, 1600.6800537109, 1677.6400146484, 1758.1700439453}
 var MonsterArmourTable = []float64{0, 22, 26, 31, 36, 42, 48, 55, 62, 70, 78, 87, 97, 107, 119, 131, 144, 158, 173, 190, 207, 226, 246, 267, 290, 315, 341, 370, 400, 432, 467, 504, 543, 585, 630, 678, 730, 785, 843, 905, 972, 1042, 1118, 1198, 1284, 1375, 1472, 1575, 1685, 1802, 1927, 2059, 2200, 2350, 2509, 2678, 2858, 3050, 3253, 3469, 3698, 3942, 4201, 4476, 4768, 5078, 5407, 5756, 6127, 6520, 6937, 7380, 7850, 8348, 8876, 9436, 10030, 10660, 11328, 12036, 12787, 13582, 14425, 15319, 16265, 17268, 18331, 19457, 20649, 21913, 23250, 24667, 26168, 27756, 29438, 31220, 33105, 35101, 37214, 39450, 41817}
 
-var UnarmedWeaponData = map[int]map[string]interface{}{
-	0: {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(6)}, // Scion
-	1: {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(8)}, // Marauder
-	2: {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(5)}, // Ranger
-	3: {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(5)}, // Witch
-	4: {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(6)}, // Duelist
-	5: {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(6)}, // Templar
-	6: {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(5)}, // Shadow
+var UnarmedWeaponData = map[ClassID]map[string]interface{}{
+	Scion:    {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(6)},
+	Marauder: {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(8)},
+	Ranger:   {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(5)},
+	Witch:    {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(5)},
+	Duelist:  {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(6)},
+	Templar:  {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(6)},
+	Shadow:   {"Type": None, "AttackRate": 1.2, "CritChance": float64(0), "PhysicalMin": float64(2), "PhysicalMax": float64(5)},
 }
 
 type SkillType string

--- a/data/types_tree.go
+++ b/data/types_tree.go
@@ -26,7 +26,7 @@ type Class struct {
 }
 
 type Ascendancy struct {
-	ID                AscendancyName   `json:"id"`
+	ID                AscendancyID     `json:"id"`
 	Name              AscendancyName   `json:"name"`
 	FlavourText       *string          `json:"flavourText,omitempty"`
 	FlavourTextColour *string          `json:"flavourTextColour,omitempty"`

--- a/data/types_tree.go
+++ b/data/types_tree.go
@@ -26,7 +26,7 @@ type Class struct {
 }
 
 type Ascendancy struct {
-	ID                AscendancyID     `json:"id"`
+	ID                AscendancyName   `json:"id"`
 	Name              AscendancyName   `json:"name"`
 	FlavourText       *string          `json:"flavourText,omitempty"`
 	FlavourTextColour *string          `json:"flavourTextColour,omitempty"`

--- a/data/types_tree.go
+++ b/data/types_tree.go
@@ -168,60 +168,86 @@ type Sprite struct {
 	Coords   map[string]Coord `json:"coords"`
 }
 
-type AscendancyName string
+type AscendancyID int
 
 const (
-	Ascendant    AscendancyName = "Ascendant"
-	Assassin     AscendancyName = "Assassin"
-	Berserker    AscendancyName = "Berserker"
-	Champion     AscendancyName = "Champion"
-	Chieftain    AscendancyName = "Chieftain"
-	Deadeye      AscendancyName = "Deadeye"
-	Elementalist AscendancyName = "Elementalist"
-	Gladiator    AscendancyName = "Gladiator"
-	Guardian     AscendancyName = "Guardian"
-	Hierophant   AscendancyName = "Hierophant"
-	Inquisitor   AscendancyName = "Inquisitor"
-	Juggernaut   AscendancyName = "Juggernaut"
-	Necromancer  AscendancyName = "Necromancer"
-	Occultist    AscendancyName = "Occultist"
-	Pathfinder   AscendancyName = "Pathfinder"
-	Raider       AscendancyName = "Raider"
-	Saboteur     AscendancyName = "Saboteur"
-	Slayer       AscendancyName = "Slayer"
-	Trickster    AscendancyName = "Trickster"
+	Ascendant AscendancyID = iota
+	Assassin
+	Berserker
+	Champion
+	Chieftain
+	Deadeye
+	Elementalist
+	Gladiator
+	Guardian
+	Hierophant
+	Inquisitor
+	Juggernaut
+	Necromancer
+	Occultist
+	Pathfinder
+	Raider
+	Saboteur
+	Slayer
+	Trickster
 )
+
+type AscendancyName string
+
+var AscendancyNameByID = map[AscendancyID]AscendancyName{
+	Ascendant:    "Ascendant",
+	Assassin:     "Assassin",
+	Berserker:    "Berserker",
+	Champion:     "Champion",
+	Chieftain:    "Chieftain",
+	Deadeye:      "Deadeye",
+	Elementalist: "Elementalist",
+	Gladiator:    "Gladiator",
+	Guardian:     "Guardian",
+	Hierophant:   "Hierophant",
+	Inquisitor:   "Inquisitor",
+	Juggernaut:   "Juggernaut",
+	Necromancer:  "Necromancer",
+	Occultist:    "Occultist",
+	Pathfinder:   "Pathfinder",
+	Raider:       "Raider",
+	Saboteur:     "Saboteur",
+	Slayer:       "Slayer",
+	Trickster:    "Trickster",
+}
+
+type ClassID int
+
+const (
+	Scion ClassID = iota
+	Marauder
+	Ranger
+	Witch
+	Duelist
+	Templar
+	Shadow
+)
+
+var ClassAscendancies = map[ClassID][]AscendancyID{
+	Scion:    {Ascendant},
+	Marauder: {Juggernaut, Berserker, Chieftain},
+	Ranger:   {Deadeye, Pathfinder, Raider},
+	Witch:    {Elementalist, Necromancer, Occultist},
+	Duelist:  {Slayer, Gladiator, Champion},
+	Templar:  {Hierophant, Inquisitor, Guardian},
+	Shadow:   {Assassin, Trickster, Saboteur},
+}
 
 type ClassName string
 
-const (
-	Duelist  ClassName = "Duelist"
-	Marauder ClassName = "Marauder"
-	Ranger   ClassName = "Ranger"
-	Scion    ClassName = "Scion"
-	Shadow   ClassName = "Shadow"
-	Templar  ClassName = "Templar"
-	Witch    ClassName = "Witch"
-)
+var ClassNameByID = map[ClassID]ClassName{
+	Scion:    "Scion",
+	Marauder: "Marauder",
+	Ranger:   "Ranger",
+	Witch:    "Witch",
+	Duelist:  "Duelist",
+	Templar:  "Templar",
+	Shadow:   "Shadow",
+}
 
 type OilType string
-
-var ClassAscendancies = map[ClassName][]AscendancyName{
-	Duelist:  {Slayer, Gladiator, Champion},
-	Marauder: {Juggernaut, Berserker, Chieftain},
-	Ranger:   {Deadeye, Pathfinder, Raider},
-	Scion:    {Ascendant},
-	Shadow:   {Assassin, Trickster, Saboteur},
-	Templar:  {Hierophant, Inquisitor, Guardian},
-	Witch:    {Elementalist, Necromancer, Occultist},
-}
-
-var ClassIDs = map[ClassName]int{
-	Duelist:  4,
-	Marauder: 1,
-	Ranger:   2,
-	Scion:    0,
-	Shadow:   6,
-	Templar:  5,
-	Witch:    3,
-}

--- a/frontend/src/lib/types/index.d.ts
+++ b/frontend/src/lib/types/index.d.ts
@@ -806,8 +806,8 @@ export declare namespace pob {
     GetNumberOption(name: string): number;
     GetStringOption(name: string): string;
     RemoveConfigOption(name: string): void;
-    SetAscendancy(ascendancyID: number): void;
-    SetClass(classID: number): void;
+    SetAscendancy(ascendancyName: string): void;
+    SetClass(className: string): void;
     SetConfigOption(value: pob.Input): void;
     SetDefaultGemLevel(gemLevel: number): void;
     SetDefaultGemQuality(gemQuality: number): void;

--- a/frontend/src/lib/types/index.d.ts
+++ b/frontend/src/lib/types/index.d.ts
@@ -245,13 +245,15 @@ export declare namespace calculator {
     Jewels?: Record<string, unknown | undefined>;
     SubGraphs?: Record<string, unknown | undefined>;
     MasterySelections?: Record<string, unknown | undefined>;
+    ClassID: number;
     ClassName: string;
+    AscendancyID: number;
     AscendancyName: string;
     AllocatedNotableCount: number;
     AllocatedMasteryCount: number;
     Class(): data.Class;
-    SelectAscendancyClass(ascendancyName: string): void;
-    SelectClass(className: string): void;
+    SelectAscendancyClass(ascendancyID: number): void;
+    SelectClass(classID: number): void;
     Tree(): (data.Tree | undefined);
   }
   interface RequirementsTable {
@@ -804,8 +806,8 @@ export declare namespace pob {
     GetNumberOption(name: string): number;
     GetStringOption(name: string): string;
     RemoveConfigOption(name: string): void;
-    SetAscendancy(ascendancy: string): void;
-    SetClass(clazz: string): void;
+    SetAscendancy(ascendancyID: number): void;
+    SetClass(classID: number): void;
     SetConfigOption(value: pob.Input): void;
     SetDefaultGemLevel(gemLevel: number): void;
     SetDefaultGemQuality(gemQuality: number): void;

--- a/pob/methods_saved.go
+++ b/pob/methods_saved.go
@@ -2,6 +2,8 @@ package pob
 
 import (
 	"strconv"
+
+	"github.com/Vilsol/go-pob/data"
 )
 
 func (b *PathOfBuilding) WithMainSocketGroup(mainSocketGroup int) *PathOfBuilding {
@@ -127,12 +129,12 @@ func (b *PathOfBuilding) DeleteAllSocketGroups() {
 	b.Skills.SkillSets[b.Skills.ActiveSkillSet-1].Skills = make([]Skill, 0)
 }
 
-func (b *PathOfBuilding) SetClass(clazz string) {
-	b.Build.ClassName = clazz
+func (b *PathOfBuilding) SetClass(classID data.ClassID) {
+	b.Build.ClassName = data.ClassNameByID[classID]
 }
 
-func (b *PathOfBuilding) SetAscendancy(ascendancy string) {
-	b.Build.AscendClassName = ascendancy
+func (b *PathOfBuilding) SetAscendancy(ascendancyID data.AscendancyID) {
+	b.Build.AscendClassName = data.AscendancyNameByID[ascendancyID]
 }
 
 func (b *PathOfBuilding) SetLevel(level int) {

--- a/pob/methods_saved.go
+++ b/pob/methods_saved.go
@@ -129,12 +129,12 @@ func (b *PathOfBuilding) DeleteAllSocketGroups() {
 	b.Skills.SkillSets[b.Skills.ActiveSkillSet-1].Skills = make([]Skill, 0)
 }
 
-func (b *PathOfBuilding) SetClass(classID data.ClassID) {
-	b.Build.ClassName = data.ClassNameByID[classID]
+func (b *PathOfBuilding) SetClass(className data.ClassName) {
+	b.Build.ClassName = className
 }
 
-func (b *PathOfBuilding) SetAscendancy(ascendancyID data.AscendancyID) {
-	b.Build.AscendClassName = data.AscendancyNameByID[ascendancyID]
+func (b *PathOfBuilding) SetAscendancy(ascendancyName data.AscendancyName) {
+	b.Build.AscendClassName = ascendancyName
 }
 
 func (b *PathOfBuilding) SetLevel(level int) {

--- a/pob/types_saved.go
+++ b/pob/types_saved.go
@@ -28,15 +28,15 @@ const (
 )
 
 type Build struct {
-	PantheonMinorGod       string           `xml:"pantheonMinorGod,attr"` // TODO Enum
-	PantheonMajorGod       string           `xml:"pantheonMajorGod,attr"` // TODO Enum
-	Bandit                 string           `xml:"bandit,attr"`           // TODO Enum
-	ViewMode               BuildViewMode    `xml:"viewMode,attr"`
-	ClassName              string           `xml:"className,attr"`       // TODO Enum
-	AscendClassName        string           `xml:"ascendClassName,attr"` // TODO Enum
-	Level                  int              `xml:"level,attr"`
-	MainSocketGroup        int              `xml:"mainSocketGroup,attr"`
-	TargetVersion          data.GameVersion `xml:"targetVersion,attr"`
+	PantheonMinorGod       string              `xml:"pantheonMinorGod,attr"` // TODO Enum
+	PantheonMajorGod       string              `xml:"pantheonMajorGod,attr"` // TODO Enum
+	Bandit                 string              `xml:"bandit,attr"`           // TODO Enum
+	ViewMode               BuildViewMode       `xml:"viewMode,attr"`
+	ClassName              data.ClassName      `xml:"className,attr"`
+	AscendClassName        data.AscendancyName `xml:"ascendClassName,attr"`
+	Level                  int                 `xml:"level,attr"`
+	MainSocketGroup        int                 `xml:"mainSocketGroup,attr"`
+	TargetVersion          data.GameVersion    `xml:"targetVersion,attr"`
 	PassiveNodes           []int64
 	PassiveNodesStartPaths map[int64][]int64
 
@@ -163,10 +163,10 @@ type Gem struct {
 }
 
 type Spec struct {
-	ClassID        int              `xml:"classID,attr"`       // TODO Enum
-	AscendClassID  int              `xml:"ascendClassID,attr"` // TODO Enum
-	TreeVersion    data.TreeVersion `xml:"treeVersion,attr"`   // TODO Enum
-	NodesAttr      string           `xml:"nodes,attr"`
-	MasteryEffects string           `xml:"masteryEffects,attr"`
-	URL            string           `xml:"URL"`
+	ClassID        data.ClassID      `xml:"classID,attr"`
+	AscendClassID  data.AscendancyID `xml:"ascendClassID,attr"`
+	TreeVersion    data.TreeVersion  `xml:"treeVersion,attr"` // TODO Enum
+	NodesAttr      string            `xml:"nodes,attr"`
+	MasteryEffects string            `xml:"masteryEffects,attr"`
+	URL            string            `xml:"URL"`
 }


### PR DESCRIPTION
Build & Spec structs within `pob/types_saved.go` now use named types (`ClassName`, `AscendancyName`) and enums (`ClassID`, `AscendancyID`) instead of strings.

1. `SelectClass(...)` & `SelectAscendancyClass(...)` within `passive_spec.go` now use enums (`ClassID`, `AscendancyID`). This behavior is identical to the original Lua implementation.
2. `ClassName` & `AscendancyName` may be retrieved by using the `ClassID` or `AscendancyID` respectively as an index within new maps: `ClassNameByID[ClassID]` & `AscendancyNameByID[AscendancyID]`
3. ~~`SetClass(...)` & `SetAscendancy(...)` within `pob/methods_saved.go` now use their respective enumerated IDs~~ 
*REVERTED* see commit [#9310a2e](https://github.com/Vilsol/go-pob/pull/20/commits/8e1f7243c69c0c9c81254c919ac5ef5c01ed91e0) and my explanation [below](https://github.com/Vilsol/go-pob/pull/20#issuecomment-2663145871).
4. `data.UnarmedWeaponData[...]` now uses the `ClassID` enum directly as an index instead of `ClassName`  (improves code readability)


_Something to note_:
I considered implementing a `String()` function for getting the `ClassName` or `AscendancyName`, but using maps with the `ClassID`/`AscendancyID` as the index seemed more straight forward and made more sense for it belonging within `types_saved.go`.

If desired, I can change the implementation to `ClassID.String()` and `AscendancyID.String()` instead of maps with their respective IDs as indexes.

I just don't know where those `String()` functions should belong as the enums and maps are in `types_saved.go`.